### PR TITLE
보유자산 폴링 1초마다 하는 비효율을 3초로 바꾼다

### DIFF
--- a/frontend/src/components/Assets/Assets.tsx
+++ b/frontend/src/components/Assets/Assets.tsx
@@ -119,7 +119,7 @@ export default function Assets() {
     };
 
     fetchAssets(); // 초기 실행
-    const interval = setInterval(fetchAssets, 1000); // 1초마다 갱신 (Polling)
+    const interval = setInterval(fetchAssets, 3000); // 3초마다 갱신 (Polling)
     return () => clearInterval(interval);
   }, []);
 


### PR DESCRIPTION
## 🔍 변경 사항
이번 PR에서 작업한 핵심 내용을 요약해 주세요.
- 1초마다 계속 돌아가면서 조금 비효율적인것을 조금은 효율적이게 3초로 바꿨다
- 

## 💡 관련 이슈
- 연관된 이슈 번호를 적어주세요. (예: Close #141)

## 🚀 주요 변경 파일
Assets.tsx

## ✅ 체크리스트
- [x] 불필요한 주석이나 print 문을 제거했나요?
- [x] 로컬 환경에서 정상 작동을 확인했나요?

